### PR TITLE
Support for dead-lettering failed messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ AMQP_URL='amqp://guest:guest@dev.rabbitmq.com:5672' node client.js
 - [x] :muscle: ~~Mocha unit tests~~ 
 - [ ] Functional tests.
 - [x] :muscle: ~~Setup Travis CI~~
-- [ ] Support for message TTL and dead-lettering ([#59](https://github.com/senecajs/seneca-amqp-transport/issues/59).
+- [x] :muscle: ~~Support for message TTL and dead-lettering~~ ([#59](https://github.com/senecajs/seneca-amqp-transport/issues/59).
 - [ ] Better support for work queues (async).
 - [ ] Don't depend on pins for routing ([#58](https://github.com/senecajs/seneca-amqp-transport/issues/58)).
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ AMQP_URL='amqp://guest:guest@dev.rabbitmq.com:5672' node client.js
 - [x] :muscle: ~~Mocha unit tests~~ 
 - [ ] Functional tests.
 - [x] :muscle: ~~Setup Travis CI~~
-- [ ] Support for message TTL and dead-lettering.
+- [ ] Support for message TTL and dead-lettering ([#59](https://github.com/senecajs/seneca-amqp-transport/issues/59).
 - [ ] Better support for work queues (async).
 - [ ] Don't depend on pins for routing ([#58](https://github.com/senecajs/seneca-amqp-transport/issues/58)).
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 This plugin allows seneca listeners and clients to communicate over [AMQP][2].
 
+> **Important notice**: If you are upgrading to `2.1.0` from an older version, _please read and follow_ instructions on [this wiki guide][13] to avoid some potential issues.
+
 ## Install
 
 ```sh
@@ -226,3 +228,4 @@ Licensed under the [MIT][12] license.
 [10]: https://github.com/senecajs/seneca-amqp-transport/pulls
 [11]: http://senecajs.org/contribute/
 [12]: ./LICENSE.md
+[13]: https://github.com/senecajs/seneca-amqp-transport/wiki/2.1.0-migration-guide

--- a/README.md
+++ b/README.md
@@ -172,9 +172,12 @@ require('seneca')()
 
 ## Run the examples
 
-There are simple examples under the `/examples` directory. To run them, just execute:
+There are simple examples under the `/examples` directory. To run them, just install latest `seneca` (if you didn't install `devDependencies`) and execute:
 
 ```sh
+#Install seneca
+npm i seneca
+
 # Start listener.js
 cd examples
 AMQP_URL='amqp://guest:guest@dev.rabbitmq.com:5672' node listener.js

--- a/defaults.json
+++ b/defaults.json
@@ -28,7 +28,7 @@
         "prefetch": 1
       },
       "queues": {
-        "prefix": "seneca",
+        "prefix": "seneca.add",
         "separator": ".",
         "options": {
           "durable": true,

--- a/defaults.json
+++ b/defaults.json
@@ -10,6 +10,19 @@
         "autoDelete": false
       }
     },
+    "deadLetter": {
+      "queue": {
+        "name": "seneca.dlq"
+      },
+      "exchange": {
+        "type": "topic",
+        "name": "seneca.dlx",
+        "options": {
+          "durable": true,
+          "autoDelete": false
+        }
+      }
+    },
     "listen": {
       "channel": {
         "prefetch": 1
@@ -18,7 +31,11 @@
         "prefix": "seneca",
         "separator": ".",
         "options": {
-          "durable": true
+          "durable": true,
+          "arguments": {
+            "x-dead-letter-exchange": "seneca.dlx",
+            "x-message-ttl": 60000
+          }
         }
       }
     },
@@ -31,7 +48,11 @@
         "separator": ".",
         "options": {
           "autoDelete": true,
-          "exclusive": true
+          "exclusive": true,
+          "arguments": {
+            "x-dead-letter-exchange": "seneca.dlx",
+            "x-message-ttl": 10000
+          }
         }
       }
     }

--- a/lib/dead-letter.js
+++ b/lib/dead-letter.js
@@ -1,0 +1,64 @@
+'use strict';
+/**
+ * Helper module used to declare AMQP
+ * queues and exchanges related to dead-lettering
+ * mechanism.
+ *
+ * @module lib/dead-letter
+ */
+const Promise = require('bluebird');
+
+// Module API
+module.exports = {
+  declareDeadLetter
+};
+
+// Routing key used in DLQ -> DLX binding
+const ROUTING_KEY = '#';
+
+function declareDeadLetterQueue(opt, channel) {
+  return channel.assertQueue(opt.name, opt.options);
+}
+
+function declareDeadLetterExchange(opt, channel) {
+  return channel.assertExchange(opt.name, opt.type, opt.options);
+}
+
+function bindDeadLetterQueue(dlq, dlx, channel) {
+  return channel.bindQueue(dlq.queue, dlx.exchange, ROUTING_KEY);
+}
+
+/**
+ * Declares an exchange and queue described by
+ * `options` and binds them with '#' as
+ * routing key.
+ *
+ * `options` is an Object matching the following schema:
+ * {
+ *   "queue": {
+ *     "name": "seneca.dlq"
+ *   },
+ *   "exchange": {
+ *     "type": "topic",
+ *     "name": "seneca.dlx",
+ *     "options": {
+ *       "durable": true,
+ *       "autoDelete": false
+ *     }
+ *   }
+ * }
+ *
+ * @param  {Objet} options   Configuration for the dead-letter queue and exchange.
+ * @param  {amqplib.Channel} channel Queue and exchange will be declared on this channel.
+ * @return {Promise}         Resolves when the exchange, queue and binding are created.
+ */
+function declareDeadLetter(options, channel) {
+  return Promise.try(() => {
+    if (options.queue && options.exchange) {
+      return Promise.all([
+        declareDeadLetterExchange(options.exchange, channel),
+        declareDeadLetterQueue(options.queue, channel)
+      ]).spread((dlx, dlq) => bindDeadLetterQueue(dlq, dlx, channel));
+    }
+  });
+}

--- a/lib/dead-letter.js
+++ b/lib/dead-letter.js
@@ -25,7 +25,10 @@ function declareDeadLetterExchange(opt, channel) {
 }
 
 function bindDeadLetterQueue(dlq, dlx, channel) {
-  return channel.bindQueue(dlq.queue, dlx.exchange, ROUTING_KEY);
+  return channel.bindQueue(dlq.queue, dlx.exchange, ROUTING_KEY)
+    .then(() => {
+      return { rk: ROUTING_KEY };
+    });
 }
 
 /**
@@ -33,7 +36,7 @@ function bindDeadLetterQueue(dlq, dlx, channel) {
  * `options` and binds them with '#' as
  * routing key.
  *
- * `options` is an Object matching the following schema:
+ * `options` is an Object matching the following example:
  * {
  *   "queue": {
  *     "name": "seneca.dlq"
@@ -54,11 +57,16 @@ function bindDeadLetterQueue(dlq, dlx, channel) {
  */
 function declareDeadLetter(options, channel) {
   return Promise.try(() => {
-    if (options.queue && options.exchange) {
+    if (channel && options.queue && options.exchange) {
       return Promise.all([
         declareDeadLetterExchange(options.exchange, channel),
         declareDeadLetterQueue(options.queue, channel)
-      ]).spread((dlx, dlq) => bindDeadLetterQueue(dlq, dlx, channel));
+      ]).spread((dlx, dlq) =>
+        bindDeadLetterQueue(dlq, dlx, channel)
+          .then((bind) => {
+            return { dlq: dlq.queue, dlx: dlx.exchange, rk: bind.rk };
+          })
+      );
     }
   });
 }

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -3,6 +3,8 @@
  * @module lib/hook
  */
 const Amqpuri = require('amqpuri');
+const Deadletter = require('./dead-letter');
+const Promise = require('bluebird');
 
 module.exports =
   class SenecaHook {
@@ -34,6 +36,7 @@ module.exports =
           .then((transport) => {
             transport.channel.on('error', done);
             return Promise.all([
+              Deadletter.declareDeadLetter(args.deadLetter, transport.channel),
               this.addCloseCmd(transport),
               this.createActor(args, transport, done)
             ]);

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -29,7 +29,9 @@ module.exports =
         var content = message.content ? message.content.toString() : undefined;
         var props = message.properties || {};
         if (!content || !props.replyTo) {
-          return this.transport.channel.nack(message);
+          // Do not requeue message if there is no payload
+          // or we don't know where to reply
+          return this.transport.channel.nack(message, false, false);
         }
         var data = this.utils.parseJSON(this.seneca, `listen-${this.options.type}`, content);
         return this.handleMessage(message, data);

--- a/package.json
+++ b/package.json
@@ -45,15 +45,15 @@
     "bluebird": "^3.4.6",
     "jsonic": "^0.2.2",
     "lodash": "^4.16.4",
-    "seneca": "^3.2.1",
     "shortid": "^2.2.6",
     "uuid": "^2.0.3"
   },
   "devDependencies": {
+    "seneca": "^3.2.1",
     "chai": "^3.5.0",
     "chai3-json-schema": "^1.2.1",
     "dirty-chai": "^1.2.2",
-    "eslint": "^3.7.1",
+    "eslint": "^3.8.0",
     "eslint-config-seneca": "^3.0.0",
     "eslint-config-xo-space": "^0.15.0",
     "eslint-plugin-hapi": "^4.0.0",

--- a/test/lib/client.test.js
+++ b/test/lib/client.test.js
@@ -45,7 +45,7 @@ const message = {
 
 var client = null;
 
-describe('Unit tests for AMQPSenecaListener module', function() {
+describe('Unit tests for client module', function() {
   before(function(done) {
     seneca.ready(function() {
       // create a new AMQPSenecaClient instance

--- a/test/lib/dead-letter.test.js
+++ b/test/lib/dead-letter.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const Chai = require('chai');
+const DirtyChai = require('dirty-chai');
+const Sinon = require('sinon');
+const SinonChai = require('sinon-chai');
+const Promise = require('bluebird');
+require('sinon-bluebird');
+Chai.should();
+Chai.use(SinonChai);
+Chai.use(DirtyChai);
+
+const DeadLetter = require('../../lib/dead-letter');
+const DEFAULT_OPTIONS = {
+  queue: {
+    name: 'seneca.dlq'
+  },
+  exchange: {
+    type: 'topic',
+    name: 'seneca.dlx',
+    options: {
+      durable: true,
+      autoDelete: false
+    }
+  }
+};
+
+describe('Unit tests for dead-letter module', function() {
+  let channel = {
+    assertQueue: (queue) => Promise.resolve({
+      queue
+    }),
+    assertExchange: (exchange) => Promise.resolve({
+      exchange
+    }),
+    bindQueue: () => Promise.resolve()
+  };
+
+  before(function() {
+    // Create spies for channel methods
+    Sinon.stub(channel, 'assertQueue', channel.assertQueue);
+    Sinon.stub(channel, 'assertExchange', channel.assertExchange);
+    Sinon.stub(channel, 'bindQueue', channel.bindQueue);
+  });
+
+  afterEach(function() {
+    // Reset the state of the stub functions
+    channel.assertQueue.reset();
+    channel.assertExchange.reset();
+    channel.bindQueue.reset();
+  });
+
+  describe('declareDeadLetter()', function() {
+    it('should return a Promise', function() {
+      DeadLetter.declareDeadLetter().should.be.instanceof(Promise);
+    });
+
+    it('should avoid any declaration if `options.queue` is not present', function(done) {
+      var options = {
+        exchange: {}
+      };
+      DeadLetter.declareDeadLetter(options, channel)
+        .then(() => {
+          Sinon.assert.notCalled(channel.assertQueue);
+          Sinon.assert.notCalled(channel.assertExchange);
+        })
+        .asCallback(done);
+    });
+
+    it('should avoid any declaration if `options.exchange` is not present', function(done) {
+      var options = {
+        queue: {}
+      };
+      DeadLetter.declareDeadLetter(options, channel)
+        .then(() => {
+          Sinon.assert.notCalled(channel.assertQueue);
+          Sinon.assert.notCalled(channel.assertExchange);
+        })
+        .asCallback(done);
+    });
+
+    it('should avoid any declaration if `channel` is null', function(done) {
+      DeadLetter.declareDeadLetter(DEFAULT_OPTIONS, null)
+        .then(() => {
+          Sinon.assert.notCalled(channel.assertQueue);
+          Sinon.assert.notCalled(channel.assertExchange);
+        })
+        .asCallback(done);
+    });
+
+    it('should declare a dead letter exchange', function(done) {
+      DeadLetter.declareDeadLetter(DEFAULT_OPTIONS, channel)
+        .then(() => {
+          var opt = DEFAULT_OPTIONS.exchange;
+          Sinon.assert.calledOnce(channel.assertExchange);
+          Sinon.assert.calledWithExactly(channel.assertExchange, opt.name, opt.type, opt.options);
+        })
+        .asCallback(done);
+    });
+
+    it('should declare a dead letter queue', function(done) {
+      DeadLetter.declareDeadLetter(DEFAULT_OPTIONS, channel)
+        .then(() => {
+          var opt = DEFAULT_OPTIONS.queue;
+          Sinon.assert.calledOnce(channel.assertQueue);
+          Sinon.assert.calledWithExactly(channel.assertQueue, opt.name, opt.options);
+        })
+        .asCallback(done);
+    });
+
+    it('should bind dead letter queue and exchange with "#" as routing key', function(done) {
+      DeadLetter.declareDeadLetter(DEFAULT_OPTIONS, channel)
+        .then(() => {
+          Sinon.assert.calledOnce(channel.bindQueue);
+          Sinon.assert.calledWithExactly(channel.bindQueue, DEFAULT_OPTIONS.queue.name, DEFAULT_OPTIONS.exchange.name, '#');
+        })
+        .asCallback(done);
+    });
+
+    it('should resolve to an object containing `dlq`, `dlx` and `rk` props', function(done) {
+      DeadLetter.declareDeadLetter(DEFAULT_OPTIONS, channel)
+        .then((dl) => {
+          // Match `dlq` property to `options.queue.name`
+          dl.should.have.property('dlq')
+            .and.equal(DEFAULT_OPTIONS.queue.name);
+          // Match `dlx` property to `options.exchange.name`
+          dl.should.have.property('dlx')
+            .and.equal(DEFAULT_OPTIONS.exchange.name);
+          // Match 'rk' property to '#'
+          dl.should.have.property('rk').and.equal('#');
+        })
+        .asCallback(done);
+    });
+  });
+});

--- a/test/lib/listener.test.js
+++ b/test/lib/listener.test.js
@@ -46,7 +46,7 @@ var message = {
 
 var listener = null;
 
-describe('Unit tests for AMQPSenecaListener module', function() {
+describe('Unit tests for listener module', function() {
   before(function(done) {
     seneca.ready(function() {
       // create a new AMQPSenecaListener instance


### PR DESCRIPTION
- Add support for a [Dead Letter mechanism](http://bitsuppliers.com/dead-lettering-with-rabbitmq/). Failing or badly routed messages will now end up in a special _dead letter queue_ instead of being silently discarded.
- Declares new `seneca.dlq` dead letter queue.
- Declares new `seneca.dlx` dead letter exchange.
- Changes queue declaration to include `x-dead-letter-exchange` and `x-message-ttl` arguments, by default.

> This _may_ lead to potential issues if you upgrade from an older version. Please, read [this wiki guide](https://github.com/senecajs/seneca-amqp-transport/wiki/2.1.0-migration-guide).

- `seneca` is no longer a dependency -> moved to `"devDependencies"`.
