### PR TITLE
Support numbers and booleans on queue name generation

### DIFF
--- a/lib/amqp-util.js
+++ b/lib/amqp-util.js
@@ -143,10 +143,10 @@ function stringify(o, separator, prefix) {
   var s = [prefix];
   _.forOwn(o, (value, k) => {
     if (_.isArray(value)) {
-      value = o[k].toString()
+      value = value.toString()
         .replace(/,/g, '_');
     } else {
-      value = value.replace(/\*/g, 'any');
+      value = value.toString().replace(/\*/g, 'any');
     }
     s.push(`${k}:${value}`);
   });

--- a/test/lib/amqp-util.test.js
+++ b/test/lib/amqp-util.test.js
@@ -124,6 +124,19 @@ describe('Unit tests for amqp-util module', function() {
       var queue = AmqpUtil.resolveListenQueue(pins, options);
       queue.should.equal('myprefix_role:entity_cmd:save_list_foo:any');
     });
+
+
+    it('should resolve numeric and boolean pins', function() {
+      var pins = [{
+        remote: 1
+      }, {
+        cmd: 'act',
+        fatal: true
+      }];
+
+      var queue = AmqpUtil.resolveListenQueue(pins);
+      queue.should.equal('seneca.remote:1.cmd:act.fatal:true');
+    });
   });
 
 
@@ -140,10 +153,22 @@ describe('Unit tests for amqp-util module', function() {
         cmd: 'list'
       }, {
         foo: '*'
+      }, {
+        remote: 1
+      }, {
+        cmd: 'log',
+        info: true,
+        prefix: '1'
       }];
 
       var topics = AmqpUtil.resolveListenTopics(pins);
-      topics.should.include.members(['cmd.save.role.entity', 'cmd.list.role.entity', 'foo.*']);
+      topics.should.include.members([
+        'cmd.save.role.entity',
+        'cmd.list.role.entity',
+        'foo.*',
+        'remote.1',
+        'cmd.log.info.true.prefix.1'
+      ]);
     });
   });
 });

--- a/test/lib/amqp-util.test.js
+++ b/test/lib/amqp-util.test.js
@@ -128,14 +128,15 @@ describe('Unit tests for amqp-util module', function() {
 
     it('should resolve numeric and boolean pins', function() {
       var pins = [{
-        remote: 1
+        remote: 1,
+        local: 33.3
       }, {
         cmd: 'act',
         fatal: true
       }];
 
       var queue = AmqpUtil.resolveListenQueue(pins);
-      queue.should.equal('seneca.remote:1.cmd:act.fatal:true');
+      queue.should.equal('seneca.remote:1.local:33.3.cmd:act.fatal:true');
     });
   });
 


### PR DESCRIPTION
Resolves #60.

- Adds test for integer and float number cases for `resolveListenQueue`.
- Adds tests for boolean values on pins for `resolveListenTopics`.