### PR TITLE
Update tests to use Sinon ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gulp-if": "^2.0.2",
     "gulp-istanbul": "^1.1.1",
     "gulp-load-plugins": "^1.5.0",
-    "gulp-mocha": "^4.1.0",
+    "gulp-mocha": "^4.2.0",
     "gulp-release": "^1.1.1",
     "pre-commit": "^1.2.2",
     "run-sequence": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,9 @@
     "pre-commit": "^1.2.2",
     "run-sequence": "^1.2.2",
     "seneca": "^3.3.0",
-    "sinon": "^1.17.7",
-    "sinon-chai": "^2.8.0"
+    "sinon": "^2.0.0",
+    "sinon-chai": "^2.8.0",
+    "sinon-test": "^1.0.1"
   },
   "pre-commit": [
     "validate"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "run-sequence": "^1.2.2",
     "seneca": "^3.3.0",
     "sinon": "^2.1.0",
-    "sinon-chai": "^2.8.0",
+    "sinon-chai": "^2.9.0",
     "sinon-test": "^1.0.1"
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "pre-commit": "^1.2.2",
     "run-sequence": "^1.2.2",
     "seneca": "^3.3.0",
-    "sinon": "^2.0.0",
+    "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",
     "sinon-test": "^1.0.1"
   },

--- a/test/lib/client/client-factory.test.js
+++ b/test/lib/client/client-factory.test.js
@@ -2,12 +2,14 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
+const sinonTest = require('sinon-test');
 const DirtyChai = require('dirty-chai');
 const SinonChai = require('sinon-chai');
 
 chai.should();
 chai.use(SinonChai);
 chai.use(DirtyChai);
+sinon.test = sinonTest.configureTest(sinon);
 
 // use the default options
 const DEFAULT_OPTIONS = require('../../../defaults').amqp;

--- a/test/lib/client/client-factory.test.js
+++ b/test/lib/client/client-factory.test.js
@@ -94,13 +94,14 @@ describe('On client-factory module', function() {
         // Create seneca.export('transport/utils') stub
         // to make it call the provided callback, which -in turn- ends up
         // calling the `act` function on the client factory
-        this.stub(transportUtils, 'make_client', (seneca, cb) => cb(null, null,
-          function(err, done) {
-            if (err) {
-              throw err;
-            }
-            return done(options.options, Function.prototype);
-          }));
+        this.stub(transportUtils, 'make_client')
+          .callsFake((seneca, cb) => cb(null, null,
+            function(err, done) {
+              if (err) {
+                throw err;
+              }
+              return done(options.options, Function.prototype);
+            }));
 
         this.stub(seneca, 'export')
           .withArgs('transport/utils').returns(transportUtils);
@@ -126,12 +127,13 @@ describe('On client-factory module', function() {
 
         // Create seneca.export('transport/utils') stub
         // to make it call the provided callback
-        this.stub(transportUtils, 'make_client', (seneca, cb) => cb(null, null,
-          Function.prototype));
+        this.stub(transportUtils, 'make_client')
+          .callsFake((seneca, cb) => cb(null, null, Function.prototype));
 
         // Make `channel#consume` call its handler function
-        this.stub(channel, 'consume', (queue, handler) => Promise.resolve()
-          .then(() => handler(reply)));
+        this.stub(channel, 'consume')
+          .callsFake((queue, handler) => Promise.resolve()
+              .then(() => handler(reply)));
 
         this.stub(seneca, 'export')
           .withArgs('transport/utils').returns(transportUtils);

--- a/test/lib/client/client.test.js
+++ b/test/lib/client/client.test.js
@@ -41,12 +41,12 @@ describe('On client module', function() {
     DEFAULT_OPTIONS.client.queues.id = 'foo';
 
     // Create spies for channel methods
-    sinon.stub(channel, 'assertQueue').callsFake(channel.assertQueue);
-    sinon.stub(channel, 'assertExchange').callsFake(channel.assertExchange);
-    sinon.stub(channel, 'consume').callsFake(channel.consume);
-    sinon.stub(channel, 'publish').callsFake(channel.publish);
-    sinon.stub(channel, 'prefetch').callsFake(channel.prefetch);
-    sinon.stub(channel, 'on').callsFake(channel.on);
+    sinon.spy(channel, 'assertQueue');
+    sinon.spy(channel, 'assertExchange');
+    sinon.spy(channel, 'consume');
+    sinon.spy(channel, 'publish');
+    sinon.spy(channel, 'prefetch');
+    sinon.spy(channel, 'on');
   });
 
   afterEach(function() {

--- a/test/lib/client/client.test.js
+++ b/test/lib/client/client.test.js
@@ -41,12 +41,12 @@ describe('On client module', function() {
     DEFAULT_OPTIONS.client.queues.id = 'foo';
 
     // Create spies for channel methods
-    sinon.stub(channel, 'assertQueue', channel.assertQueue);
-    sinon.stub(channel, 'assertExchange', channel.assertExchange);
-    sinon.stub(channel, 'consume', channel.consume);
-    sinon.stub(channel, 'publish', channel.publish);
-    sinon.stub(channel, 'prefetch', channel.prefetch);
-    sinon.stub(channel, 'on', channel.on);
+    sinon.stub(channel, 'assertQueue').callsFake(channel.assertQueue);
+    sinon.stub(channel, 'assertExchange').callsFake(channel.assertExchange);
+    sinon.stub(channel, 'consume').callsFake(channel.consume);
+    sinon.stub(channel, 'publish').callsFake(channel.publish);
+    sinon.stub(channel, 'prefetch').callsFake(channel.prefetch);
+    sinon.stub(channel, 'on').callsFake(channel.on);
   });
 
   afterEach(function() {

--- a/test/lib/client/publisher.test.js
+++ b/test/lib/client/publisher.test.js
@@ -40,7 +40,7 @@ describe('On publisher module', function() {
 
     before(function() {
       // Create spies for channel methods
-      sinon.stub(channel, 'publish', channel.publish);
+      sinon.stub(channel, 'publish').callsFake(channel.publish);
     });
 
     afterEach(function() {
@@ -100,7 +100,7 @@ describe('On publisher module', function() {
 
     before(function() {
       // Create spies for channel methods
-      sinon.stub(channel, 'consume', channel.consume);
+      sinon.stub(channel, 'consume').callsFake(channel.consume);
     });
 
     afterEach(function() {
@@ -140,7 +140,7 @@ describe('On publisher module', function() {
     before(function() {
       // Stub `channel#consume` method and make it call the `consumeReply`
       // callback with a mock `reply` object
-      sinon.stub(channel, 'consume', (queue, cb) => cb(reply));
+      sinon.stub(channel, 'consume').callsFake((queue, cb) => cb(reply));
     });
 
     afterEach(function() {
@@ -179,7 +179,7 @@ describe('On publisher module', function() {
 
       // Stub `channel#consume` method and make it call the `consumeReply`
       // callback with a mock `reply` object with no `content` property.
-      sinon.stub(noContentChannel, 'consume', (queue, cb) => cb({
+      sinon.stub(noContentChannel, 'consume').callsFake((queue, cb) => cb({
         properties: reply.properties
       }));
 

--- a/test/lib/client/publisher.test.js
+++ b/test/lib/client/publisher.test.js
@@ -40,7 +40,7 @@ describe('On publisher module', function() {
 
     before(function() {
       // Create spies for channel methods
-      sinon.stub(channel, 'publish').callsFake(channel.publish);
+      sinon.spy(channel, 'publish');
     });
 
     afterEach(function() {
@@ -100,7 +100,7 @@ describe('On publisher module', function() {
 
     before(function() {
       // Create spies for channel methods
-      sinon.stub(channel, 'consume').callsFake(channel.consume);
+      sinon.spy(channel, 'consume');
     });
 
     afterEach(function() {

--- a/test/lib/common/dead-letter.test.js
+++ b/test/lib/common/dead-letter.test.js
@@ -35,9 +35,9 @@ describe('On dead-letter module', function() {
 
   before(function() {
     // Create spies for channel methods
-    sinon.stub(channel, 'assertQueue', channel.assertQueue);
-    sinon.stub(channel, 'assertExchange', channel.assertExchange);
-    sinon.stub(channel, 'bindQueue', channel.bindQueue);
+    sinon.stub(channel, 'assertQueue').callsFake(channel.assertQueue);
+    sinon.stub(channel, 'assertExchange').callsFake(channel.assertExchange);
+    sinon.stub(channel, 'bindQueue').callsFake(channel.bindQueue);
   });
 
   afterEach(function() {

--- a/test/lib/common/dead-letter.test.js
+++ b/test/lib/common/dead-letter.test.js
@@ -35,9 +35,9 @@ describe('On dead-letter module', function() {
 
   before(function() {
     // Create spies for channel methods
-    sinon.stub(channel, 'assertQueue').callsFake(channel.assertQueue);
-    sinon.stub(channel, 'assertExchange').callsFake(channel.assertExchange);
-    sinon.stub(channel, 'bindQueue').callsFake(channel.bindQueue);
+    sinon.spy(channel, 'assertQueue');
+    sinon.spy(channel, 'assertExchange');
+    sinon.spy(channel, 'bindQueue');
   });
 
   afterEach(function() {

--- a/test/lib/listener/consumer.test.js
+++ b/test/lib/listener/consumer.test.js
@@ -38,7 +38,7 @@ describe('On consumer module', function() {
 
     before(function() {
       // Create spies for channel methods
-      sinon.stub(channel, 'consume', channel.consume);
+      sinon.stub(channel, 'consume').callsFake(channel.consume);
     });
 
     afterEach(function() {
@@ -144,7 +144,7 @@ describe('On consumer module', function() {
       };
 
       // Create spies for channel methods
-      sinon.stub(channel, 'nack', channel.nack);
+      sinon.stub(channel, 'nack').callsFake(channel.nack);
 
       var messageHandler = sinon.spy();
       var consumer = Consumer(channel, { messageHandler });
@@ -172,7 +172,7 @@ describe('On consumer module', function() {
       };
 
       // Create spies for channel methods
-      sinon.stub(channel, 'nack', channel.nack);
+      sinon.stub(channel, 'nack').callsFake(channel.nack);
 
       var messageHandler = sinon.spy();
       var consumer = Consumer(channel, { messageHandler });

--- a/test/lib/listener/consumer.test.js
+++ b/test/lib/listener/consumer.test.js
@@ -38,7 +38,7 @@ describe('On consumer module', function() {
 
     before(function() {
       // Create spies for channel methods
-      sinon.stub(channel, 'consume').callsFake(channel.consume);
+      sinon.spy(channel, 'consume');
     });
 
     afterEach(function() {
@@ -144,7 +144,7 @@ describe('On consumer module', function() {
       };
 
       // Create spies for channel methods
-      sinon.stub(channel, 'nack').callsFake(channel.nack);
+      sinon.spy(channel, 'nack');
 
       var messageHandler = sinon.spy();
       var consumer = Consumer(channel, { messageHandler });
@@ -172,7 +172,7 @@ describe('On consumer module', function() {
       };
 
       // Create spies for channel methods
-      sinon.stub(channel, 'nack').callsFake(channel.nack);
+      sinon.spy(channel, 'nack');
 
       var messageHandler = sinon.spy();
       var consumer = Consumer(channel, { messageHandler });

--- a/test/lib/listener/listener-factory.test.js
+++ b/test/lib/listener/listener-factory.test.js
@@ -3,12 +3,14 @@
 const Promise = require('bluebird');
 const chai = require('chai');
 const sinon = require('sinon');
+const sinonTest = require('sinon-test');
 const DirtyChai = require('dirty-chai');
 const SinonChai = require('sinon-chai');
 
 chai.should();
 chai.use(SinonChai);
 chai.use(DirtyChai);
+sinon.test = sinonTest.configureTest(sinon);
 
 // use the default options
 const DEFAULT_OPTIONS = require('../../../defaults').amqp;
@@ -50,7 +52,7 @@ describe('On listener-factory module', function() {
 
   describe('the Listener#listen() function', function() {
     before(function() {
-      sinon.stub(channel, 'consume', channel.consume);
+      sinon.stub(channel, 'consume').callsFake(channel.consume);
     });
 
     afterEach(function() {
@@ -107,9 +109,9 @@ describe('On listener-factory module', function() {
     before(function() {
       // Stub the `channel#consume()` method to make it call the message
       // handler function as if a new message had just arrived to the queue
-      sinon.stub(channel, 'consume', channel.consume);
-      sinon.stub(channel, 'sendToQueue', channel.sendToQueue);
-      sinon.stub(channel, 'ack', channel.ack);
+      sinon.stub(channel, 'consume').callsFake(channel.consume);
+      sinon.stub(channel, 'sendToQueue').callsFake(channel.sendToQueue);
+      sinon.stub(channel, 'ack').callsFake(channel.ack);
     });
 
     afterEach(function() {

--- a/test/lib/listener/listener-factory.test.js
+++ b/test/lib/listener/listener-factory.test.js
@@ -52,11 +52,11 @@ describe('On listener-factory module', function() {
 
   describe('the Listener#listen() function', function() {
     before(function() {
-      sinon.stub(channel, 'consume').callsFake(channel.consume);
+      sinon.spy(channel, 'consume');
     });
 
     afterEach(function() {
-      // Reset the state of the stub functions
+      // Reset the state of the spy functions
       channel.consume.reset();
     });
 
@@ -109,9 +109,9 @@ describe('On listener-factory module', function() {
     before(function() {
       // Stub the `channel#consume()` method to make it call the message
       // handler function as if a new message had just arrived to the queue
-      sinon.stub(channel, 'consume').callsFake(channel.consume);
-      sinon.stub(channel, 'sendToQueue').callsFake(channel.sendToQueue);
-      sinon.stub(channel, 'ack').callsFake(channel.ack);
+      sinon.spy(channel, 'consume');
+      sinon.spy(channel, 'sendToQueue');
+      sinon.spy(channel, 'ack');
     });
 
     afterEach(function() {

--- a/test/lib/listener/listener-factory.test.js
+++ b/test/lib/listener/listener-factory.test.js
@@ -169,8 +169,8 @@ describe('On listener-factory module', function() {
         // Could be any "falsy" value
         var reply = false;
 
-        this.stub(transportUtils, 'handle_request',
-          (seneca, data, options, cb) => cb(reply));
+        this.stub(transportUtils, 'handle_request')
+        .callsFake((seneca, data, options, cb) => cb(reply));
 
         this.stub(seneca, 'export')
             .withArgs('transport/utils').returns(transportUtils);

--- a/test/lib/listener/listener.test.js
+++ b/test/lib/listener/listener.test.js
@@ -42,10 +42,10 @@ describe('On listener module', function() {
     DEFAULT_OPTIONS.pin = 'role:entity,cmd:create';
 
     // Create spies for channel methods
-    sinon.stub(channel, 'assertQueue').callsFake(channel.assertQueue);
-    sinon.stub(channel, 'assertExchange').callsFake(channel.assertExchange);
-    sinon.stub(channel, 'prefetch').callsFake(channel.prefetch);
-    sinon.stub(channel, 'bindQueue').callsFake(channel.bindQueue);
+    sinon.spy(channel, 'assertQueue');
+    sinon.spy(channel, 'assertExchange');
+    sinon.spy(channel, 'prefetch');
+    sinon.spy(channel, 'bindQueue');
   });
 
   before(function(done) {

--- a/test/lib/listener/listener.test.js
+++ b/test/lib/listener/listener.test.js
@@ -42,10 +42,10 @@ describe('On listener module', function() {
     DEFAULT_OPTIONS.pin = 'role:entity,cmd:create';
 
     // Create spies for channel methods
-    sinon.stub(channel, 'assertQueue', channel.assertQueue);
-    sinon.stub(channel, 'assertExchange', channel.assertExchange);
-    sinon.stub(channel, 'prefetch', channel.prefetch);
-    sinon.stub(channel, 'bindQueue', channel.bindQueue);
+    sinon.stub(channel, 'assertQueue').callsFake(channel.assertQueue);
+    sinon.stub(channel, 'assertExchange').callsFake(channel.assertExchange);
+    sinon.stub(channel, 'prefetch').callsFake(channel.prefetch);
+    sinon.stub(channel, 'bindQueue').callsFake(channel.bindQueue);
   });
 
   before(function(done) {


### PR DESCRIPTION
Migrate syntax using the [Migration Guide](http://sinonjs.org/releases/v2.1.0/migrating-to-2.0/).