### PR TITLE
Add prettier support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,17 +1,12 @@
 {
-  "extends": "seneca",
+  "extends": ["eslint:recommended", "plugin:prettier/recommended"],
   "env": {
-    "mocha": true
+    "node": true,
+    "mocha": true,
+    "es6": true
   },
   "rules": {
     "semi": [2, "always"],
-    "no-extra-semi": 2,
-    "semi-spacing": [2, { "before": false, "after": true }],
-    "callback-return": [2, ["callback", "cb", "next", "done"]],
-    "no-unused-vars": [2, { "vars": "all", "args": "after-used" }],
-    "space-before-function-paren": [2, "never"],
-    "brace-style": [2, "1tbs",  { "allowSingleLine": false }],
-    "arrow-parens": ["error", "always"],
-    "hapi/hapi-capitalize-modules": [0, "always"]
+    "no-console": 0
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/e2e/client.e2e.js
+++ b/e2e/client.e2e.js
@@ -13,38 +13,43 @@ const QUEUE_NAME = 'seneca.add.cmd:test.role:client';
 const EXCHANGE_NAME = 'seneca.topic';
 const RK = 'cmd.test.role.client';
 
-describe('A Seneca client with type:\'amqp\'', function() {
+describe("A Seneca client with type:'amqp'", function() {
   var ch = null;
-  var client = seneca.use('..', {
-    exchange: {
-      name: EXCHANGE_NAME,
-      options: {
-        durable: false,
-        autoDelete: true
+  var client = seneca
+    .use('..', {
+      exchange: {
+        name: EXCHANGE_NAME,
+        options: {
+          durable: false,
+          autoDelete: true
+        }
       }
-    }
-  })
-  .client({
-    url: process.env.AMQP_URL,
-    type: 'amqp',
-    pin: 'cmd:test,role:client'
-  });
+    })
+    .client({
+      url: process.env.AMQP_URL,
+      type: 'amqp',
+      pin: 'cmd:test,role:client'
+    });
 
   before(function(done) {
-    seneca.ready((err) => done(err));
+    seneca.ready(err => done(err));
   });
 
   before(function() {
     // Connect to the broker, (re-)declare exchange and queue used in test
     // and remove any pre-existing messages from it
-    return amqp.connect(process.env.AMQP_UR)
-      .then((conn) => conn.createChannel())
-      .then((channel) => {
-        return channel.deleteQueue(QUEUE_NAME)
-          .then(() => channel.assertQueue(QUEUE_NAME, {
-            durable: false,
-            exclusive: true
-          }))
+    return amqp
+      .connect(process.env.AMQP_UR)
+      .then(conn => conn.createChannel())
+      .then(channel => {
+        return channel
+          .deleteQueue(QUEUE_NAME)
+          .then(() =>
+            channel.assertQueue(QUEUE_NAME, {
+              durable: false,
+              exclusive: true
+            })
+          )
           .then(() => channel.assertExchange(EXCHANGE_NAME, 'topic'))
           .then(() => channel.bindQueue(QUEUE_NAME, EXCHANGE_NAME, RK))
           .thenReturn(channel);
@@ -61,68 +66,81 @@ describe('A Seneca client with type:\'amqp\'', function() {
 
   after(function() {
     // Close both the channel and the connection to the AMQP broker
-    return ch.close()
-      .then(() => ch.connection.close());
+    return ch.close().then(() => ch.connection.close());
   });
 
   after(function() {
     seneca.close();
   });
 
-  it('should publish a valid message to an AMQP queue after a call to `act()`',
-    function(done) {
-      var payload = {
-        foo: 'bar',
-        life: 42
-      };
+  it('should publish a valid message to an AMQP queue after a call to `act()`', function(done) {
+    var payload = {
+      foo: 'bar',
+      life: 42
+    };
 
-      ch.consume(QUEUE_NAME, function(message) {
+    ch.consume(
+      QUEUE_NAME,
+      function(message) {
         message.properties.should.be.an('object');
         message.properties.should.have.property('correlationId').that.is.ok();
         message.properties.should.have.property('replyTo').that.is.ok();
 
         var content = JSON.parse(message.content.toString());
         content.should.have.property('act').that.is.an('object');
-        content.act.should.eql(Object.assign({
-          cmd: 'test',
-          role: 'client'
-        }, payload));
+        content.act.should.eql(
+          Object.assign(
+            {
+              cmd: 'test',
+              role: 'client'
+            },
+            payload
+          )
+        );
         return done();
-      }, { consumerTag: CONSUMER_TAG });
+      },
+      { consumerTag: CONSUMER_TAG }
+    );
 
-      client.act('cmd:test,role:client', payload);
-    });
+    client.act('cmd:test,role:client', payload);
+  });
 
-  it('should call the `act()` callback when replying',
-    function(done) {
-      var utils = seneca.export('transport/utils');
-      var payload = {
-        foo: 'bar',
-        life: 42
-      };
-      var respose = {
-        bar: 'baz'
-      };
+  it('should call the `act()` callback when replying', function(done) {
+    var utils = seneca.export('transport/utils');
+    var payload = {
+      foo: 'bar',
+      life: 42
+    };
+    var respose = {
+      bar: 'baz'
+    };
 
-      ch.consume(QUEUE_NAME, function(message) {
+    ch.consume(
+      QUEUE_NAME,
+      function(message) {
         var data = JSON.parse(message.content.toString());
         var reply = utils.prepareResponse(seneca, data);
         reply.res = respose;
         // Send a response to the `replyTo` queue
         // This should trigger the act callback function
-        ch.sendToQueue(message.properties.replyTo,
-          Buffer.from(JSON.stringify(reply)), {
+        ch.sendToQueue(
+          message.properties.replyTo,
+          Buffer.from(JSON.stringify(reply)),
+          {
             correlationId: message.properties.correlationId
-          });
-      }, { consumerTag: CONSUMER_TAG });
+          }
+        );
+      },
+      { consumerTag: CONSUMER_TAG }
+    );
 
-      client.act('cmd:test,role:client', payload, function(err, res) {
-        if (err) {
-          return done(err);
-        }
+    client.act('cmd:test,role:client', payload, function(err, res) {
+      if (err) {
+        return done(err);
+      }
 
-        res.should.eql(respose);
-        return done();
-      });
+      res.should.eql(respose);
+      return done();
     });
+  });
 });

--- a/e2e/listener.e2e.js
+++ b/e2e/listener.e2e.js
@@ -13,18 +13,20 @@ const EXCHANGE_NAME = 'seneca.topic';
 const RK = 'cmd.test.role.listener';
 
 function deleteQueue(ch, queue) {
-  return ch.deleteQueue(queue)
+  return ch
+    .deleteQueue(queue)
     .thenReturn(ch)
     .catch(() => ch.connection.createChannel());
 }
 
 function deleteExchange(ch, queue) {
-  return ch.deleteExchange(queue)
+  return ch
+    .deleteExchange(queue)
     .thenReturn(ch)
     .catch(() => ch.connection.createChannel());
 }
 
-describe('A Seneca listener with type:\'amqp\'', function() {
+describe("A Seneca listener with type:'amqp'", function() {
   var ch = null;
   var listener = seneca.use('..', {
     exchange: {
@@ -48,10 +50,11 @@ describe('A Seneca listener with type:\'amqp\'', function() {
     // Connect to the broker, delete queue and exchange, and then declare
     // the actual listener. This is to properly test creation of needed AMQP
     // elements during listener initialization.
-    return amqp.connect(process.env.AMQP_URL)
-      .then((conn) => conn.createChannel())
-      .then((channel) => deleteQueue(channel, QUEUE_NAME))
-      .then((channel) => deleteExchange(channel, EXCHANGE_NAME))
+    return amqp
+      .connect(process.env.AMQP_URL)
+      .then(conn => conn.createChannel())
+      .then(channel => deleteQueue(channel, QUEUE_NAME))
+      .then(channel => deleteExchange(channel, EXCHANGE_NAME))
       .then(function(channel) {
         seneca.listen({
           type: 'amqp',
@@ -70,8 +73,7 @@ describe('A Seneca listener with type:\'amqp\'', function() {
     // Close both the channel and the connection to the AMQP broker
     // Declared queue and exchange should be automatically deleted on
     // disconnection
-    return ch.close()
-      .then(() => ch.connection.close());
+    return ch.close().then(() => ch.connection.close());
   });
 
   after(function() {
@@ -79,35 +81,35 @@ describe('A Seneca listener with type:\'amqp\'', function() {
   });
 
   it('should declare a new properly named queue in the broker', function(done) {
-    ch.checkQueue(QUEUE_NAME)
+    ch
+      .checkQueue(QUEUE_NAME)
       .then(function(ok) {
         ok.queue.should.eq(QUEUE_NAME);
-      }).asCallback(done);
-  });
-
-  it('should declare an exchange in the broker', function(done) {
-    ch.checkExchange(EXCHANGE_NAME)
+      })
       .asCallback(done);
   });
 
-  it('should call the `add()` callback when a new message is published',
-    function(done) {
-      var message = {
-        kind: 'act',
-        time: { client_sent: Date.now() },
-        act: { cmd: 'test' },
-        sync: true
-      };
+  it('should declare an exchange in the broker', function(done) {
+    ch.checkExchange(EXCHANGE_NAME).asCallback(done);
+  });
 
-      listener.add('cmd:test', function(payload, cb) {
-        var received = seneca.util.clean(payload);
-        received.should.eql(message.act);
-        cb(null, { ok: true });
-        return done();
-      });
+  it('should call the `add()` callback when a new message is published', function(done) {
+    var message = {
+      kind: 'act',
+      time: { client_sent: Date.now() },
+      act: { cmd: 'test' },
+      sync: true
+    };
 
-      ch.publish(EXCHANGE_NAME, RK, Buffer.from(JSON.stringify(message)), {
-        replyTo: 'reply.queue'
-      });
+    listener.add('cmd:test', function(payload, cb) {
+      var received = seneca.util.clean(payload);
+      received.should.eql(message.act);
+      cb(null, { ok: true });
+      return done();
     });
+
+    ch.publish(EXCHANGE_NAME, RK, Buffer.from(JSON.stringify(message)), {
+      replyTo: 'reply.queue'
+    });
+  });
 });

--- a/examples/client.js
+++ b/examples/client.js
@@ -10,14 +10,18 @@ const client = require('seneca')()
   });
 
 setInterval(function() {
-  client.act('cmd:salute', {
-    name: 'World',
-    max: 100,
-    min: 25
-  }, (err, res) => {
-    if (err) {
-      throw err;
+  client.act(
+    'cmd:salute',
+    {
+      name: 'World',
+      max: 100,
+      min: 25
+    },
+    (err, res) => {
+      if (err) {
+        throw err;
+      }
+      console.log(res);
     }
-    console.log(res);
-  });
+  );
 }, 2000);

--- a/examples/listener.js
+++ b/examples/listener.js
@@ -1,17 +1,19 @@
 #!/usr/bin/env node
 'use strict';
 
-const Path = require('path');
+const path = require('path');
 
 require('seneca')()
   .use('..')
   .add('cmd:salute', function(message, done) {
     return done(null, {
-      id: Math.floor(Math.random() * (message.max - message.min + 1)) + message.min,
+      id:
+        Math.floor(Math.random() * (message.max - message.min + 1)) +
+        message.min,
       message: `Hello ${message.name}!`,
       from: {
         pid: process.pid,
-        file: Path.relative(process.cwd(), __filename)
+        file: path.relative(process.cwd(), __filename)
       },
       now: Date.now()
     });

--- a/examples/log-client.js
+++ b/examples/log-client.js
@@ -10,12 +10,16 @@ const client = require('seneca')()
   });
 
 setInterval(function() {
-  client.act('cmd:log,level:log', {
-    message: 'Hello World'
-  }, (err, res) => {
-    if (err) {
-      throw err;
+  client.act(
+    'cmd:log,level:log',
+    {
+      message: 'Hello World'
+    },
+    (err, res) => {
+      if (err) {
+        throw err;
+      }
+      console.log(res);
     }
-    console.log(res);
-  });
+  );
 }, 2000);

--- a/examples/multipin-client.js
+++ b/examples/multipin-client.js
@@ -10,31 +10,43 @@ const client = require('seneca')()
   });
 
 setInterval(function() {
-  client.act('action:get_time', {
-    id: Math.floor(Math.random() * 91) + 10
-  }, (err, res) => {
-    if (err) {
-      throw err;
+  client.act(
+    'action:get_time',
+    {
+      id: Math.floor(Math.random() * 91) + 10
+    },
+    (err, res) => {
+      if (err) {
+        throw err;
+      }
+      console.log(res);
     }
-    console.log(res);
-  });
+  );
 
-  client.act('level:log', {
-    id: Math.floor(Math.random() * 91) + 10,
-    text: '[level:log] Print out this random number: ' + 100 * Math.random()
-  }, (err, res) => {
-    if (err) {
-      throw err;
+  client.act(
+    'level:log',
+    {
+      id: Math.floor(Math.random() * 91) + 10,
+      text: '[level:log] Print out this random number: ' + 100 * Math.random()
+    },
+    (err, res) => {
+      if (err) {
+        throw err;
+      }
+      console.log(res);
     }
-    console.log(res);
-  });
+  );
 
-  client.act('proc:status', {
-    id: Math.floor(Math.random() * 91) + 10
-  }, (err, res) => {
-    if (err) {
-      throw err;
+  client.act(
+    'proc:status',
+    {
+      id: Math.floor(Math.random() * 91) + 10
+    },
+    (err, res) => {
+      if (err) {
+        throw err;
+      }
+      console.log(res);
     }
-    console.log(res);
-  });
+  );
 }, 500);

--- a/examples/multipin-listener.js
+++ b/examples/multipin-listener.js
@@ -11,7 +11,9 @@ require('seneca')()
     });
   })
   .add('level:log', function(message, done) {
-    console[message.level](`[level:log] Action ${message.id} wants to log: ${message.text}`);
+    console[message.level](
+      `[level:log] Action ${message.id} wants to log: ${message.text}`
+    );
     return done(null, {
       pid: process.pid,
       status: `Message ${message.id} logged successfully`

--- a/index.js
+++ b/index.js
@@ -18,16 +18,22 @@ module.exports = function(opts) {
   var options = seneca.util.deepextend(defaults, so.transport, opts);
   var listener = hooks.listenerHook(seneca);
   var client = hooks.clientHook(seneca);
-  seneca.add({
-    role: 'transport',
-    hook: 'listen',
-    type: TRANSPORT_TYPE
-  }, listener.hook(options));
-  seneca.add({
-    role: 'transport',
-    hook: 'client',
-    type: TRANSPORT_TYPE
-  }, client.hook(options));
+  seneca.add(
+    {
+      role: 'transport',
+      hook: 'listen',
+      type: TRANSPORT_TYPE
+    },
+    listener.hook(options)
+  );
+  seneca.add(
+    {
+      role: 'transport',
+      hook: 'client',
+      type: TRANSPORT_TYPE
+    },
+    client.hook(options)
+  );
 
   return {
     tag: PLUGIN_TAG,

--- a/lib/client/client-factory.js
+++ b/lib/client/client-factory.js
@@ -44,13 +44,18 @@ function createClient(seneca, { ch, queue, exchange, options = {} }) {
 
   function act(args, done) {
     const outmsg = utils.prepare_request(seneca, args, done);
-    const outstr = utils.stringifyJSON(seneca, `client-${options.type}`, outmsg);
+    const outstr = utils.stringifyJSON(
+      seneca,
+      `client-${options.type}`,
+      outmsg
+    );
     const topic = amqputil.resolveClientTopic(args);
     return pub.publish(outstr, exchange, topic, options.publish);
   }
 
   function callback(spec, topic, sendDone) {
-    return pub.awaitReply()
+    return pub
+      .awaitReply()
       .then(() => sendDone(null, act))
       .catch(sendDone);
   }
@@ -67,11 +72,12 @@ function createClient(seneca, { ch, queue, exchange, options = {} }) {
      */
     start(done) {
       ch.on('error', done);
-      return Promise.resolve(utils.make_client(seneca, callback, options, done))
-        .then(() => {
-          this.started = true;
-          return this;
-        });
+      return Promise.resolve(
+        utils.make_client(seneca, callback, options, done)
+      ).then(() => {
+        this.started = true;
+        return this;
+      });
     }
   };
 

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -48,8 +48,7 @@ function declareRoute(ch, options) {
  */
 function createActor(seneca, { ch, queue, exchange, options }, done) {
   const client = Client(seneca, { ch, queue, exchange, options });
-  return Promise.resolve(client.start(done))
-    .thenReturn(client);
+  return Promise.resolve(client.start(done)).thenReturn(client);
 }
 
 /**
@@ -64,8 +63,7 @@ function createActor(seneca, { ch, queue, exchange, options }, done) {
  *                    declared.
  */
 function setup(seneca, { ch, options }, done) {
-  return declareRoute(ch, options)
-    .then(function({ queue, exchange }) {
-      return createActor(seneca, { ch, queue, exchange, options }, done);
-    });
+  return declareRoute(ch, options).then(function({ queue, exchange }) {
+    return createActor(seneca, { ch, queue, exchange, options }, done);
+  });
 }

--- a/lib/client/publisher.js
+++ b/lib/client/publisher.js
@@ -18,14 +18,17 @@ module.exports = createPublisher;
  */
 const JSON_CONTENT_TYPE = 'application/json';
 
-function createPublisher(ch, {
-  replyQueue, replyHandler, correlationId = uuid.v4()
-} = {}) {
+function createPublisher(
+  ch,
+  { replyQueue, replyHandler, correlationId = uuid.v4() } = {}
+) {
   if (!isObject(ch)) {
-    throw new TypeError('Channel parameter `ch` must be provided (got: [' +
-      typeof ch + '])');
+    throw new TypeError(
+      'Channel parameter `ch` must be provided (got: [' + typeof ch + '])'
+    );
   }
-  const handleReply = isFunction(replyHandler) ? replyHandler
+  const handleReply = isFunction(replyHandler)
+    ? replyHandler
     : Function.prototype;
 
   function publish(message, exchange, rk, options) {

--- a/lib/common/dead-letter.js
+++ b/lib/common/dead-letter.js
@@ -49,7 +49,8 @@ function declareDeadLetterExchange(channel, opt) {
  * @return {Promise}         [description]
  */
 function bindDeadLetterQueue(dlq, dlx, channel) {
-  return channel.bindQueue(dlq.queue, dlx.exchange, ROUTING_KEY)
+  return channel
+    .bindQueue(dlq.queue, dlx.exchange, ROUTING_KEY)
     .thenReturn({ rk: ROUTING_KEY });
 }
 
@@ -86,10 +87,9 @@ function declareDeadLetter(channel, options) {
         declareDeadLetterExchange(channel, options.exchange),
         declareDeadLetterQueue(channel, options.queue)
       ).spread((dlx, dlq) =>
-        bindDeadLetterQueue(dlq, dlx, channel)
-          .then((bind) => {
-            return { dlq: dlq.queue, dlx: dlx.exchange, rk: bind.rk };
-          })
+        bindDeadLetterQueue(dlq, dlx, channel).then(bind => {
+          return { dlq: dlq.queue, dlx: dlx.exchange, rk: bind.rk };
+        })
       );
     }
   });

--- a/lib/common/hooker.js
+++ b/lib/common/hooker.js
@@ -29,7 +29,8 @@ module.exports = {
  *                         connection has been closed.
  */
 function closer(ch, done) {
-  return ch.close()
+  return ch
+    .close()
     .then(() => ch.connection.close())
     .asCallback(done);
 }
@@ -49,10 +50,9 @@ function closer(ch, done) {
 function buildPluginOptions(seneca, args, options) {
   const { clean, deepextend } = seneca.util;
   const amqpUrl = amqpuri.format(args);
-  return Object.assign(
-    clean(deepextend(options[args.type], args)),
-    { url: amqpUrl }
-  );
+  return Object.assign(clean(deepextend(options[args.type], args)), {
+    url: amqpUrl
+  });
 }
 
 /**
@@ -71,15 +71,17 @@ function hook(options) {
   const terminateConnection = curry(closer);
   return (args, done) => {
     const pluginOptions = buildPluginOptions(this.seneca, args, options);
-    return amqp.connect(pluginOptions.url, pluginOptions.socketOptions)
-      .then((conn) => conn.createChannel())
-      .then((ch) => {
+    return amqp
+      .connect(pluginOptions.url, pluginOptions.socketOptions)
+      .then(conn => conn.createChannel())
+      .then(ch => {
         ch.on('error', done);
         transportUtils.close(this.seneca, terminateConnection(ch));
         return Promise.join(
           this.setup(this.seneca, { ch, options: pluginOptions }, done),
           deadletter.declareDeadLetter(ch, pluginOptions.deadLetter)
         );
-      }).catch(done);
+      })
+      .catch(done);
   };
 }

--- a/lib/listener/consumer.js
+++ b/lib/listener/consumer.js
@@ -11,11 +11,13 @@ module.exports = createConsumer;
 
 function createConsumer(ch, { queue, messageHandler } = {}) {
   if (!isObject(ch)) {
-    throw new TypeError('Channel parameter `ch` must be provided (got: [' +
-      typeof ch + '])');
+    throw new TypeError(
+      'Channel parameter `ch` must be provided (got: [' + typeof ch + '])'
+    );
   }
 
-  const handleMessage = isFunction(messageHandler) ? messageHandler
+  const handleMessage = isFunction(messageHandler)
+    ? messageHandler
     : Function.prototype;
 
   const createReplyWith = curry((message, response) => {

--- a/lib/listener/index.js
+++ b/lib/listener/index.js
@@ -44,10 +44,15 @@ function declareRoute(seneca, { ch, options }) {
   ).spread((exchange, pins) => {
     const topics = amqputil.resolveListenTopics(pins);
     const qlisten = options.listener.queues;
-    const queue = trim(options.name) || amqputil.resolveListenQueue(pins, qlisten);
-    return ch.assertQueue(queue, qlisten.options)
-      .then((q) => Promise.map(topics,
-        (topic) => ch.bindQueue(q.queue, exchange.exchange, topic)))
+    const queue =
+      trim(options.name) || amqputil.resolveListenQueue(pins, qlisten);
+    return ch
+      .assertQueue(queue, qlisten.options)
+      .then(q =>
+        Promise.map(topics, topic =>
+          ch.bindQueue(q.queue, exchange.exchange, topic)
+        )
+      )
       .thenReturn({ exchange: exchange.exchange, queue });
   });
 }
@@ -66,7 +71,8 @@ function declareRoute(seneca, { ch, options }) {
  */
 function createActor(seneca, { ch, queue, options }, done) {
   const listener = Listener(seneca, { ch, queue, options });
-  return listener.listen()
+  return listener
+    .listen()
     .then(() => done())
     .thenReturn(listener);
 }
@@ -84,8 +90,7 @@ function createActor(seneca, { ch, queue, options }, done) {
  *                    declared and bound.
  */
 function setup(seneca, { ch, options }, done) {
-  return declareRoute(seneca, { ch, options })
-    .then(({ queue }) => {
-      return createActor(seneca, { ch, queue, options }, done);
-    });
+  return declareRoute(seneca, { ch, options }).then(({ queue }) => {
+    return createActor(seneca, { ch, queue, options }, done);
+  });
 }

--- a/lib/listener/listener-factory.js
+++ b/lib/listener/listener-factory.js
@@ -62,11 +62,10 @@ function createListener(seneca, { ch, queue, options = {} }) {
      *                   messages.
      */
     listen() {
-      return consumer.consume(queue, options.consume)
-        .then(() => {
-          this.started = true;
-          return this;
-        });
+      return consumer.consume(queue, options.consume).then(() => {
+        this.started = true;
+        return this;
+      });
     }
   };
 

--- a/lib/listener/listener-util.js
+++ b/lib/listener/listener-util.js
@@ -62,7 +62,7 @@ function resolveListenQueue(pins, { prefix = '', separator = '.' } = {}) {
  */
 function resolveListenTopics(pins) {
   pins = castArray(pins);
-  const topics = pins.map((p) => topic.resolveTopic(p));
+  const topics = pins.map(p => topic.resolveTopic(p));
   return topics;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -616,6 +616,15 @@
         "text-table": "0.2.0"
       }
     },
+    "eslint-config-prettier": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
+      "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "5.0.1"
+      }
+    },
     "eslint-config-seneca": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-seneca/-/eslint-config-seneca-3.0.0.tgz",
@@ -633,6 +642,16 @@
         "hapi-no-var": "1.0.1",
         "hapi-scope-start": "2.1.1",
         "no-arrowception": "1.0.0"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
       }
     },
     "eslint-plugin-standard": {
@@ -736,6 +755,12 @@
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -828,6 +853,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "gex": {
@@ -1107,6 +1138,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
       "dev": true
     },
     "js-tokens": {
@@ -3239,6 +3276,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
+      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "validate": "npm-run-all lint test:unit",
     "integrate": "npm-run-all lint coverage",
     "release": "./scripts/release.sh",
-    "prettier": "prettier index.js lib/*.js test/*.js"
+    "prettier": "prettier --write index.js lib/**/*.js examples/**/*.js e2e/**/*.js test/**/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint index.js lib test",
     "validate": "npm-run-all lint test:unit",
     "integrate": "npm-run-all lint coverage",
-    "release": "./scripts/release.sh"
+    "release": "./scripts/release.sh",
+    "prettier": "prettier index.js lib/*.js test/*.js"
   },
   "repository": {
     "type": "git",
@@ -57,20 +58,23 @@
     "uuid": "^3.1.0"
   },
   "devDependencies": {
-    "mocha": "^4.1.0",
     "chai": "^4.1.2",
     "chai-json-schema": "^1.5.0",
     "dirty-chai": "^2.0.1",
     "eslint": "^4.15.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-config-seneca": "^3.0.0",
     "eslint-plugin-hapi": "^4.1.0",
+    "eslint-plugin-prettier": "^2.4.0",
     "eslint-plugin-standard": "^3.0.1",
+    "mocha": "^4.1.0",
+    "npm-run-all": "^4.1.2",
+    "nyc": "^11.4.1",
     "pre-commit": "^1.2.2",
+    "prettier": "^1.10.2",
     "seneca": "^3.4.3",
     "sinon": "^4.1.5",
-    "sinon-chai": "^2.14.0",
-    "npm-run-all": "^4.1.2",
-    "nyc": "^11.4.1"
+    "sinon-chai": "^2.14.0"
   },
   "pre-commit": [
     "validate"

--- a/test/lib/client/client-util.test.js
+++ b/test/lib/client/client-util.test.js
@@ -22,12 +22,11 @@ describe('On client-util module', function() {
       queue.should.equal('secret_id');
     });
 
-    it('should use no prefix or separator if no options are provided',
-      function() {
-        var queue = amqputil.resolveClientQueue();
-        // queue name should contain no prefix or separator
-        queue.should.match(/^[A-F0-9]+$/i);
-      });
+    it('should use no prefix or separator if no options are provided', function() {
+      var queue = amqputil.resolveClientQueue();
+      // queue name should contain no prefix or separator
+      queue.should.match(/^[A-F0-9]+$/i);
+    });
 
     it('should use custom prefix and default separator', function() {
       var options = {

--- a/test/lib/client/client.test.js
+++ b/test/lib/client/client.test.js
@@ -18,8 +18,8 @@ const client = require('../../../lib/client');
 
 describe('On client module', function() {
   let channel = {
-    assertQueue: (queue) => Promise.resolve({ queue }),
-    assertExchange: (exchange) => Promise.resolve({ exchange }),
+    assertQueue: queue => Promise.resolve({ queue }),
+    assertExchange: exchange => Promise.resolve({ exchange }),
     consume: () => Promise.resolve(),
     publish: () => Promise.resolve(),
     prefetch: Function.prototype,
@@ -61,13 +61,15 @@ describe('On client module', function() {
 
   describe('the setup() function', function() {
     it('should return a Promise', function() {
-      client.setup(seneca, options, Function.prototype)
+      client
+        .setup(seneca, options, Function.prototype)
         .should.be.instanceof(Promise);
     });
 
     it('should resolve to a new Client instance', function(done) {
-      client.setup(seneca, options, Function.prototype)
-        .then((cl) => {
+      client
+        .setup(seneca, options, Function.prototype)
+        .then(cl => {
           cl.should.be.an('object');
           cl.should.have.property('start');
         })
@@ -75,40 +77,50 @@ describe('On client module', function() {
     });
 
     it('should have started the new client', function(done) {
-      client.setup(seneca, options, Function.prototype)
-        .then((cl) => cl.started.should.be.true())
+      client
+        .setup(seneca, options, Function.prototype)
+        .then(cl => cl.started.should.be.true())
         .asCallback(done);
     });
 
     it('should set the prefetch value on the channel', function(done) {
-      client.setup(seneca, options, Function.prototype)
+      client
+        .setup(seneca, options, Function.prototype)
         .then(() => {
           channel.prefetch.should.have.been.calledOnce();
-          channel.prefetch.should.have.been
-            .calledWith(DEFAULT_OPTIONS.client.channel.prefetch);
+          channel.prefetch.should.have.been.calledWith(
+            DEFAULT_OPTIONS.client.channel.prefetch
+          );
         })
         .asCallback(done);
     });
 
     it('should declare the exchange on the channel', function(done) {
-      client.setup(seneca, options, Function.prototype)
+      client
+        .setup(seneca, options, Function.prototype)
         .then(() => {
           var ex = DEFAULT_OPTIONS.exchange;
           channel.assertExchange.should.have.been.calledOnce();
-          channel.assertExchange.should.have.been
-            .calledWith(ex.name, ex.type, ex.options);
+          channel.assertExchange.should.have.been.calledWith(
+            ex.name,
+            ex.type,
+            ex.options
+          );
         })
         .asCallback(done);
     });
 
     it('should declare the queue on the channel', function(done) {
-      client.setup(seneca, options, Function.prototype)
+      client
+        .setup(seneca, options, Function.prototype)
         .then(() => {
           var queueOptions = DEFAULT_OPTIONS.client.queues;
           var queueName = amqputil.resolveClientQueue(queueOptions);
           channel.assertQueue.should.have.been.calledOnce();
-          channel.assertQueue.should.have.been
-            .calledWith(queueName, queueOptions.options);
+          channel.assertQueue.should.have.been.calledWith(
+            queueName,
+            queueOptions.options
+          );
         })
         .asCallback(done);
     });

--- a/test/lib/client/publisher.test.js
+++ b/test/lib/client/publisher.test.js
@@ -29,7 +29,7 @@ describe('On publisher module', function() {
     });
 
     it('should throw if no channel is provided', function() {
-      (Publisher).should.throw(TypeError, /provided/);
+      Publisher.should.throw(TypeError, /provided/);
     });
   });
 
@@ -56,8 +56,11 @@ describe('On publisher module', function() {
       pub.publish(message, EXCHANGE, rk);
 
       channel.publish.should.have.been.calledOnce();
-      channel.publish.should.have.been.calledWith(sinon.match.string,
-        sinon.match.string, Buffer.from(message));
+      channel.publish.should.have.been.calledWith(
+        sinon.match.string,
+        sinon.match.string,
+        Buffer.from(message)
+      );
     });
 
     it('should publish to the given exchange and routing key', function() {
@@ -70,36 +73,48 @@ describe('On publisher module', function() {
 
     it('should set the `replyTo` option', function(done) {
       const pub = Publisher(channel, { replyQueue: 'reply.queue' });
-      pub.publish(message, EXCHANGE, rk)
+      pub
+        .publish(message, EXCHANGE, rk)
         .then(function() {
           channel.publish.should.have.been.calledOnce();
-          channel.publish.should.have.been.calledWith(sinon.match.string,
-            sinon.match.string, sinon.match.defined,
-            sinon.match.has('replyTo', 'reply.queue'));
+          channel.publish.should.have.been.calledWith(
+            sinon.match.string,
+            sinon.match.string,
+            sinon.match.defined,
+            sinon.match.has('replyTo', 'reply.queue')
+          );
         })
         .asCallback(done);
     });
 
     it('should set the `correlationId` option', function(done) {
       const pub = Publisher(channel, { correlationId: CORRELATION_ID });
-      pub.publish(message, EXCHANGE, rk)
+      pub
+        .publish(message, EXCHANGE, rk)
         .then(function() {
           channel.publish.should.have.been.calledOnce();
-          channel.publish.should.have.been.calledWith(sinon.match.string,
-            sinon.match.string, sinon.match.defined,
-            sinon.match.has('correlationId', CORRELATION_ID));
+          channel.publish.should.have.been.calledWith(
+            sinon.match.string,
+            sinon.match.string,
+            sinon.match.defined,
+            sinon.match.has('correlationId', CORRELATION_ID)
+          );
         })
         .asCallback(done);
     });
 
     it('should set channel#publish options', function(done) {
       const pub = Publisher(channel, { correlationId: CORRELATION_ID });
-      pub.publish(message, EXCHANGE, rk, { persistent: true })
+      pub
+        .publish(message, EXCHANGE, rk, { persistent: true })
         .then(function() {
           channel.publish.should.have.been.calledOnce();
-          channel.publish.should.have.been.calledWith(sinon.match.string,
-            sinon.match.string, sinon.match.defined,
-            sinon.match.has('persistent', true));
+          channel.publish.should.have.been.calledWith(
+            sinon.match.string,
+            sinon.match.string,
+            sinon.match.defined,
+            sinon.match.has('persistent', true)
+          );
         })
         .asCallback(done);
     });
@@ -127,11 +142,15 @@ describe('On publisher module', function() {
 
     it('should await for reply messages from the channel', function(done) {
       const pub = Publisher(channel, { replyQueue: 'reply.queue' });
-      pub.awaitReply()
+      pub
+        .awaitReply()
         .then(function() {
           channel.consume.should.have.been.calledOnce();
-          channel.consume.should.have.been.calledWith('reply.queue',
-            sinon.match.func, { noAck: true });
+          channel.consume.should.have.been.calledWith(
+            'reply.queue',
+            sinon.match.func,
+            { noAck: true }
+          );
         })
         .asCallback(done);
     });
@@ -191,9 +210,11 @@ describe('On publisher module', function() {
 
       // Stub `channel#consume` method and make it call the `consumeReply`
       // callback with a mock `reply` object with no `content` property.
-      sinon.stub(noContentChannel, 'consume').callsFake((queue, cb) => cb({
-        properties: reply.properties
-      }));
+      sinon.stub(noContentChannel, 'consume').callsFake((queue, cb) =>
+        cb({
+          properties: reply.properties
+        })
+      );
 
       const replyHandler = sinon.spy();
       const pub = Publisher(noContentChannel, {

--- a/test/lib/common/dead-letter.test.js
+++ b/test/lib/common/dead-letter.test.js
@@ -6,7 +6,6 @@ const DirtyChai = require('dirty-chai');
 const SinonChai = require('sinon-chai');
 const Promise = require('bluebird');
 
-
 chai.should();
 chai.use(SinonChai);
 chai.use(DirtyChai);
@@ -28,8 +27,8 @@ const DEFAULT_OPTIONS = {
 
 describe('On dead-letter module', function() {
   let channel = {
-    assertQueue: (queue) => Promise.resolve({ queue }),
-    assertExchange: (exchange) => Promise.resolve({ exchange }),
+    assertQueue: queue => Promise.resolve({ queue }),
+    assertExchange: exchange => Promise.resolve({ exchange }),
     bindQueue: () => Promise.resolve()
   };
 
@@ -56,7 +55,8 @@ describe('On dead-letter module', function() {
       var options = {
         exchange: {}
       };
-      deadLetter.declareDeadLetter(channel, options)
+      deadLetter
+        .declareDeadLetter(channel, options)
         .then(() => {
           sinon.assert.notCalled(channel.assertQueue);
           sinon.assert.notCalled(channel.assertExchange);
@@ -68,7 +68,8 @@ describe('On dead-letter module', function() {
       var options = {
         queue: {}
       };
-      deadLetter.declareDeadLetter(channel, options)
+      deadLetter
+        .declareDeadLetter(channel, options)
         .then(() => {
           sinon.assert.notCalled(channel.assertQueue);
           sinon.assert.notCalled(channel.assertExchange);
@@ -77,7 +78,8 @@ describe('On dead-letter module', function() {
     });
 
     it('should avoid any declaration if `channel` is null', function(done) {
-      deadLetter.declareDeadLetter(null, DEFAULT_OPTIONS)
+      deadLetter
+        .declareDeadLetter(null, DEFAULT_OPTIONS)
         .then(() => {
           sinon.assert.notCalled(channel.assertQueue);
           sinon.assert.notCalled(channel.assertExchange);
@@ -86,42 +88,60 @@ describe('On dead-letter module', function() {
     });
 
     it('should declare a dead letter exchange', function(done) {
-      deadLetter.declareDeadLetter(channel, DEFAULT_OPTIONS)
+      deadLetter
+        .declareDeadLetter(channel, DEFAULT_OPTIONS)
         .then(() => {
           var opt = DEFAULT_OPTIONS.exchange;
           sinon.assert.calledOnce(channel.assertExchange);
-          sinon.assert.calledWithExactly(channel.assertExchange, opt.name, opt.type, opt.options);
+          sinon.assert.calledWithExactly(
+            channel.assertExchange,
+            opt.name,
+            opt.type,
+            opt.options
+          );
         })
         .asCallback(done);
     });
 
     it('should declare a dead letter queue', function(done) {
-      deadLetter.declareDeadLetter(channel, DEFAULT_OPTIONS)
+      deadLetter
+        .declareDeadLetter(channel, DEFAULT_OPTIONS)
         .then(() => {
           var opt = DEFAULT_OPTIONS.queue;
           sinon.assert.calledOnce(channel.assertQueue);
-          sinon.assert.calledWithExactly(channel.assertQueue, opt.name, opt.options);
+          sinon.assert.calledWithExactly(
+            channel.assertQueue,
+            opt.name,
+            opt.options
+          );
         })
         .asCallback(done);
     });
 
     it('should bind dead letter queue and exchange with "#" as routing key', function(done) {
-      deadLetter.declareDeadLetter(channel, DEFAULT_OPTIONS)
+      deadLetter
+        .declareDeadLetter(channel, DEFAULT_OPTIONS)
         .then(() => {
           sinon.assert.calledOnce(channel.bindQueue);
-          sinon.assert.calledWithExactly(channel.bindQueue, DEFAULT_OPTIONS.queue.name, DEFAULT_OPTIONS.exchange.name, '#');
+          sinon.assert.calledWithExactly(
+            channel.bindQueue,
+            DEFAULT_OPTIONS.queue.name,
+            DEFAULT_OPTIONS.exchange.name,
+            '#'
+          );
         })
         .asCallback(done);
     });
 
     it('should resolve to an object containing `dlq`, `dlx` and `rk` props', function(done) {
-      deadLetter.declareDeadLetter(channel, DEFAULT_OPTIONS)
-        .then((dl) => {
+      deadLetter
+        .declareDeadLetter(channel, DEFAULT_OPTIONS)
+        .then(dl => {
           // Match `dlq` property to `options.queue.name`
-          dl.should.have.property('dlq')
-            .and.equal(DEFAULT_OPTIONS.queue.name);
+          dl.should.have.property('dlq').and.equal(DEFAULT_OPTIONS.queue.name);
           // Match `dlx` property to `options.exchange.name`
-          dl.should.have.property('dlx')
+          dl.should.have
+            .property('dlx')
             .and.equal(DEFAULT_OPTIONS.exchange.name);
           // Match 'rk' property to '#'
           dl.should.have.property('rk').and.equal('#');

--- a/test/lib/listener/consumer.test.js
+++ b/test/lib/listener/consumer.test.js
@@ -27,7 +27,7 @@ describe('On consumer module', function() {
     });
 
     it('should throw if no channel is provided', function() {
-      (Consumer).should.throw(TypeError, /provided/);
+      Consumer.should.throw(TypeError, /provided/);
     });
   });
 
@@ -56,8 +56,11 @@ describe('On consumer module', function() {
       consumer.consume(QUEUE, { noAck: true });
 
       channel.consume.should.have.been.calledOnce();
-      channel.consume.should.have.been.calledWith(QUEUE,
-        sinon.match.func, sinon.match.has('noAck', true));
+      channel.consume.should.have.been.calledWith(
+        QUEUE,
+        sinon.match.func,
+        sinon.match.has('noAck', true)
+      );
     });
 
     it('should start consuming from given queue on the channel', function() {
@@ -68,75 +71,76 @@ describe('On consumer module', function() {
       channel.consume.should.have.been.calledWith(QUEUE, sinon.match.func);
     });
 
-    it('should consume from the queue given at creation time if not provided',
-      function() {
-        const consumer = Consumer(channel, {
-          queue: QUEUE
-        });
-        consumer.consume();
-
-        channel.consume.should.have.been.calledOnce();
-        channel.consume.should.have.been.calledWith(QUEUE, sinon.match.func);
+    it('should consume from the queue given at creation time if not provided', function() {
+      const consumer = Consumer(channel, {
+        queue: QUEUE
       });
+      consumer.consume();
+
+      channel.consume.should.have.been.calledOnce();
+      channel.consume.should.have.been.calledWith(QUEUE, sinon.match.func);
+    });
   });
 
   describe('the onMessage() function', function() {
-    it('should call a message handler function on receiving a valid message',
-      function(done) {
-        const message = {
-          content: JSON.stringify({ foo: 'bar' }),
-          properties: {
-            correlationId: 'bf6c362d-ca8b-4fa6-b052-2bb462e1b7b5',
-            replyTo: 'reply.queue'
-          }
-        };
+    it('should call a message handler function on receiving a valid message', function(done) {
+      const message = {
+        content: JSON.stringify({ foo: 'bar' }),
+        properties: {
+          correlationId: 'bf6c362d-ca8b-4fa6-b052-2bb462e1b7b5',
+          replyTo: 'reply.queue'
+        }
+      };
 
-        const channel = {
-          ack: Function.prototype,
-          consume: (queue, handler) => Promise.resolve()
-            .then(() => handler(message))
-        };
+      const channel = {
+        ack: Function.prototype,
+        consume: (queue, handler) =>
+          Promise.resolve().then(() => handler(message))
+      };
 
-        const messageHandler = sinon.spy();
-        const consumer = Consumer(channel, { messageHandler });
-        consumer.consume()
-          .then(function() {
-            messageHandler.should.have.been.calledOnce();
-            messageHandler.should.have.been.calledWith(message.content,
-              sinon.match.func);
-          })
-          .asCallback(done);
-      });
+      const messageHandler = sinon.spy();
+      const consumer = Consumer(channel, { messageHandler });
+      consumer
+        .consume()
+        .then(function() {
+          messageHandler.should.have.been.calledOnce();
+          messageHandler.should.have.been.calledWith(
+            message.content,
+            sinon.match.func
+          );
+        })
+        .asCallback(done);
+    });
 
-    it('should reject a message if the message handler throws an error',
-      function(done) {
-        const message = {
-          content: JSON.stringify({ foo: 'bar' }),
-          properties: {
-            correlationId: 'bf6c362d-ca8b-4fa6-b052-2bb462e1b7b5',
-            replyTo: 'reply.queue'
-          }
-        };
+    it('should reject a message if the message handler throws an error', function(done) {
+      const message = {
+        content: JSON.stringify({ foo: 'bar' }),
+        properties: {
+          correlationId: 'bf6c362d-ca8b-4fa6-b052-2bb462e1b7b5',
+          replyTo: 'reply.queue'
+        }
+      };
 
-        const channel = {
-          nack: Function.prototype,
-          consume: (queue, handler) => Promise.resolve()
-            .then(() => handler(message))
-        };
+      const channel = {
+        nack: Function.prototype,
+        consume: (queue, handler) =>
+          Promise.resolve().then(() => handler(message))
+      };
 
-        const messageHandler = function() {
-          throw new Error();
-        };
+      const messageHandler = function() {
+        throw new Error();
+      };
 
-        const nack = sinon.spy(channel, 'nack');
-        const consumer = Consumer(channel, { messageHandler });
-        consumer.consume()
-          .then(function() {
-            nack.should.have.been.calledOnce();
-            nack.should.have.been.calledWith(message, false, false);
-          })
-          .asCallback(done);
-      });
+      const nack = sinon.spy(channel, 'nack');
+      const consumer = Consumer(channel, { messageHandler });
+      consumer
+        .consume()
+        .then(function() {
+          nack.should.have.been.calledOnce();
+          nack.should.have.been.calledWith(message, false, false);
+        })
+        .asCallback(done);
+    });
 
     it('should reject a message if no content is defined', function(done) {
       const message = {
@@ -147,8 +151,8 @@ describe('On consumer module', function() {
       };
 
       const channel = {
-        consume: (queue, handler) => Promise.resolve()
-          .then(() => handler(message)),
+        consume: (queue, handler) =>
+          Promise.resolve().then(() => handler(message)),
         nack: () => Promise.resolve()
       };
 
@@ -157,7 +161,8 @@ describe('On consumer module', function() {
 
       const messageHandler = sinon.spy();
       const consumer = Consumer(channel, { messageHandler });
-      consumer.consume()
+      consumer
+        .consume()
         .then(function() {
           messageHandler.should.not.have.been.called();
           channel.nack.should.have.been.calledOnce();
@@ -175,8 +180,8 @@ describe('On consumer module', function() {
       };
 
       const channel = {
-        consume: (queue, handler) => Promise.resolve()
-          .then(() => handler(message)),
+        consume: (queue, handler) =>
+          Promise.resolve().then(() => handler(message)),
         nack: () => Promise.resolve()
       };
 
@@ -185,7 +190,8 @@ describe('On consumer module', function() {
 
       const messageHandler = sinon.spy();
       const consumer = Consumer(channel, { messageHandler });
-      consumer.consume()
+      consumer
+        .consume()
         .then(function() {
           messageHandler.should.not.have.been.called();
           channel.nack.should.have.been.calledOnce();

--- a/test/lib/listener/listener-factory.test.js
+++ b/test/lib/listener/listener-factory.test.js
@@ -65,11 +65,14 @@ describe('On listener-factory module', function() {
 
     it('should start consuming messages from a queue', function(done) {
       var listener = Listener(seneca, options);
-      listener.listen()
+      listener
+        .listen()
         .then(() => {
           channel.consume.should.have.been.calledOnce();
-          channel.consume.should.have.been.calledWith(options.queue,
-            sinon.match.func);
+          channel.consume.should.have.been.calledWith(
+            options.queue,
+            sinon.match.func
+          );
         })
         .asCallback(done);
     });
@@ -91,8 +94,8 @@ describe('On listener-factory module', function() {
     };
 
     const channel = {
-      consume: (queue, handler) => Promise.resolve()
-        .then(() => handler(message)),
+      consume: (queue, handler) =>
+        Promise.resolve().then(() => handler(message)),
       sendToQueue: () => Promise.resolve(),
       ack: Function.prototype
     };
@@ -111,7 +114,8 @@ describe('On listener-factory module', function() {
       sinon.spy(channel, 'sendToQueue');
       sinon.spy(channel, 'ack');
 
-      sinon.stub(seneca, 'export')
+      sinon
+        .stub(seneca, 'export')
         .withArgs('transport/utils')
         .returns(transportUtils);
     });
@@ -127,49 +131,59 @@ describe('On listener-factory module', function() {
       var handleRequest = sinon.spy(transportUtils, 'handle_request');
 
       var listener = Listener(seneca, options);
-      listener.listen()
+      listener
+        .listen()
         .then(() => {
           handleRequest.should.have.been.calledOnce();
-          handleRequest.should.have.been.calledWith(seneca, { foo: 'bar' },
-            DEFAULT_OPTIONS, sinon.match.func);
+          handleRequest.should.have.been.calledWith(
+            seneca,
+            { foo: 'bar' },
+            DEFAULT_OPTIONS,
+            sinon.match.func
+          );
         })
         .asCallback(done);
     });
 
-    it('should reply to the `replyTo` queue with the response from a Seneca act',
-      function(done) {
-        var reply = { foo: 'bar' };
+    it('should reply to the `replyTo` queue with the response from a Seneca act', function(done) {
+      var reply = { foo: 'bar' };
 
-        sinon.stub(transportUtils, 'handle_request')
-          .callsFake((seneca, data, options, cb) => cb(reply));
+      sinon
+        .stub(transportUtils, 'handle_request')
+        .callsFake((seneca, data, options, cb) => cb(reply));
 
-        var listener = Listener(seneca, options);
-        listener.listen()
-          .then(() => {
-            // Should send response to `replyTo` queue
-            channel.sendToQueue.should.have.been.calledOnce();
-            channel.sendToQueue.should
-              .have.been.calledWith(message.properties.replyTo,
-                Buffer.from(JSON.stringify(reply)), {
-                  correlationId: message.properties.correlationId
-                });
+      var listener = Listener(seneca, options);
+      listener
+        .listen()
+        .then(() => {
+          // Should send response to `replyTo` queue
+          channel.sendToQueue.should.have.been.calledOnce();
+          channel.sendToQueue.should.have.been.calledWith(
+            message.properties.replyTo,
+            Buffer.from(JSON.stringify(reply)),
+            {
+              correlationId: message.properties.correlationId
+            }
+          );
 
-            // Should acknowledge the message on the channel
-            channel.ack.should.have.been.calledOnce();
-            channel.ack.should.have.been.calledWith(message);
-          })
-          .asCallback(done);
-      });
+          // Should acknowledge the message on the channel
+          channel.ack.should.have.been.calledOnce();
+          channel.ack.should.have.been.calledWith(message);
+        })
+        .asCallback(done);
+    });
 
     it('should not reply to the `replyTo` queue if response is falsy', function(done) {
       // Could be any "falsy" value
       var reply = false;
 
-      sinon.stub(transportUtils, 'handle_request')
+      sinon
+        .stub(transportUtils, 'handle_request')
         .callsFake((seneca, data, options, cb) => cb(reply));
 
       var listener = Listener(seneca, options);
-      listener.listen()
+      listener
+        .listen()
         .then(() => {
           // Should not send response to `replyTo` queue
           channel.sendToQueue.should.not.have.been.calledOnce();

--- a/test/lib/listener/listener-util.test.js
+++ b/test/lib/listener/listener-util.test.js
@@ -34,30 +34,38 @@ describe('On listener-util module', function() {
     });
 
     it('should resolve multiple pins', function() {
-      var pins = [{
-        role: 'entity',
-        cmd: ['save', 'read', 'delete']
-      }, {
-        role: 'entity',
-        cmd: 'list'
-      }, {
-        foo: '*'
-      }];
+      var pins = [
+        {
+          role: 'entity',
+          cmd: ['save', 'read', 'delete']
+        },
+        {
+          role: 'entity',
+          cmd: 'list'
+        },
+        {
+          foo: '*'
+        }
+      ];
 
       var queue = amqputil.resolveListenQueue(pins);
       queue.should.equal('role:entity.cmd:save_read_delete_list.foo:any');
     });
 
     it('should resolve multiple pins by honoring custom prefix and separator', function() {
-      var pins = [{
-        role: 'entity',
-        cmd: 'save'
-      }, {
-        role: 'entity',
-        cmd: 'list'
-      }, {
-        foo: '*'
-      }];
+      var pins = [
+        {
+          role: 'entity',
+          cmd: 'save'
+        },
+        {
+          role: 'entity',
+          cmd: 'list'
+        },
+        {
+          foo: '*'
+        }
+      ];
 
       var options = {
         prefix: 'seneca',
@@ -68,48 +76,56 @@ describe('On listener-util module', function() {
       queue.should.equal('seneca_role:entity_cmd:save_list_foo:any');
     });
 
-
     it('should resolve numeric and boolean pins', function() {
-      var pins = [{
-        remote: 1,
-        local: 33.3
-      }, {
-        cmd: 'act',
-        fatal: true
-      }];
+      var pins = [
+        {
+          remote: 1,
+          local: 33.3
+        },
+        {
+          cmd: 'act',
+          fatal: true
+        }
+      ];
 
       var queue = amqputil.resolveListenQueue(pins);
       queue.should.equal('remote:1.local:33.3.cmd:act.fatal:true');
     });
   });
 
-
   /**
    * Function: resolveListenTopics()
    */
   describe('the resolveListenTopics()', function() {
     it('should return an array of topics based on the array of pins', function() {
-      var pins = [{
-        role: 'entity',
-        cmd: 'save'
-      }, {
-        role: 'entity',
-        cmd: 'list'
-      }, {
-        foo: '*'
-      }, {
-        remote: 1
-      }, {
-        cmd: 'log',
-        info: true,
-        prefix: '1'
-      }, {
-        cmd: 'update',
-        role: 'entity',
-        version: 'v1.0.0',
-        method: 'GET',
-        remote: 1
-      }];
+      var pins = [
+        {
+          role: 'entity',
+          cmd: 'save'
+        },
+        {
+          role: 'entity',
+          cmd: 'list'
+        },
+        {
+          foo: '*'
+        },
+        {
+          remote: 1
+        },
+        {
+          cmd: 'log',
+          info: true,
+          prefix: '1'
+        },
+        {
+          cmd: 'update',
+          role: 'entity',
+          version: 'v1.0.0',
+          method: 'GET',
+          remote: 1
+        }
+      ];
 
       var topics = amqputil.resolveListenTopics(pins);
       topics.should.include.members([

--- a/test/lib/listener/listener.test.js
+++ b/test/lib/listener/listener.test.js
@@ -16,12 +16,14 @@ const listener = require('../../../lib/listener');
 
 describe('On listener module', function() {
   let channel = {
-    assertQueue: (queue) => Promise.resolve({
-      queue
-    }),
-    assertExchange: (exchange) => Promise.resolve({
-      exchange
-    }),
+    assertQueue: queue =>
+      Promise.resolve({
+        queue
+      }),
+    assertExchange: exchange =>
+      Promise.resolve({
+        exchange
+      }),
     consume: () => Promise.resolve(),
     publish: () => Promise.resolve(),
     bindQueue: () => Promise.resolve(),
@@ -66,13 +68,15 @@ describe('On listener module', function() {
     });
 
     it('should return a Promise', function() {
-      listener.setup(seneca, options, Function.prototype)
+      listener
+        .setup(seneca, options, Function.prototype)
         .should.be.instanceof(Promise);
     });
 
     it('should resolve to a new Listener instance', function(done) {
-      listener.setup(seneca, options, Function.prototype)
-        .then((li) => {
+      listener
+        .setup(seneca, options, Function.prototype)
+        .then(li => {
           li.should.be.an('object');
           li.should.have.property('listen');
         })
@@ -80,60 +84,79 @@ describe('On listener module', function() {
     });
 
     it('should have started the new listener', function(done) {
-      listener.setup(seneca, options, Function.prototype)
-        .then((li) => {
+      listener
+        .setup(seneca, options, Function.prototype)
+        .then(li => {
           li.started.should.be.true();
         })
         .asCallback(done);
     });
 
     it('should set the prefetch value on the channel', function(done) {
-      listener.setup(seneca, options, Function.prototype)
+      listener
+        .setup(seneca, options, Function.prototype)
         .then(() => {
           channel.prefetch.should.have.been.calledOnce();
-          channel.prefetch.should.have.been
-            .calledWith(DEFAULT_OPTIONS.listener.channel.prefetch);
+          channel.prefetch.should.have.been.calledWith(
+            DEFAULT_OPTIONS.listener.channel.prefetch
+          );
         })
         .asCallback(done);
     });
 
     it('should declare the exchange on the channel', function(done) {
-      listener.setup(seneca, options, Function.prototype)
+      listener
+        .setup(seneca, options, Function.prototype)
         .then(() => {
           var ex = DEFAULT_OPTIONS.exchange;
           channel.assertExchange.should.have.been.calledOnce();
-          channel.assertExchange.should.have.been
-            .calledWith(ex.name, ex.type, ex.options);
+          channel.assertExchange.should.have.been.calledWith(
+            ex.name,
+            ex.type,
+            ex.options
+          );
         })
         .asCallback(done);
     });
 
     it('should declare the queue on the channel', function(done) {
-      listener.setup(seneca, options, Function.prototype)
+      listener
+        .setup(seneca, options, Function.prototype)
         .then(() => {
           var queueOptions = DEFAULT_OPTIONS.listener.queues;
-          var queueName = amqputil.resolveListenQueue({
-            role: 'entity',
-            cmd: 'create'
-          }, queueOptions);
+          var queueName = amqputil.resolveListenQueue(
+            {
+              role: 'entity',
+              cmd: 'create'
+            },
+            queueOptions
+          );
           channel.assertQueue.should.have.been.calledOnce();
-          channel.assertQueue.should.have.been
-            .calledWith(queueName, queueOptions.options);
+          channel.assertQueue.should.have.been.calledWith(
+            queueName,
+            queueOptions.options
+          );
         })
         .asCallback(done);
     });
 
     it('should bind the queue to the exchange', function(done) {
-      listener.setup(seneca, options, Function.prototype)
+      listener
+        .setup(seneca, options, Function.prototype)
         .then(() => {
           var queueOptions = DEFAULT_OPTIONS.listener.queues;
-          var queueName = amqputil.resolveListenQueue({
-            role: 'entity',
-            cmd: 'create'
-          }, queueOptions);
+          var queueName = amqputil.resolveListenQueue(
+            {
+              role: 'entity',
+              cmd: 'create'
+            },
+            queueOptions
+          );
           channel.bindQueue.should.have.been.calledOnce();
-          channel.bindQueue.should.have.been
-            .calledWith(queueName, DEFAULT_OPTIONS.exchange.name);
+          channel.bindQueue.should.have.been.calledWith(
+            queueName,
+            DEFAULT_OPTIONS.exchange.name
+          );
         })
         .asCallback(done);
     });


### PR DESCRIPTION
- Add `prettier` formatter to project (matches new Seneca general styling).
- Configure `eslint` to enforce `prettier` rules.
- Format all sources to match new rules.