### PR TITLE
Replacing dots with underscores in PLUGIN_TAG 

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const defaults = require('./defaults');
 const hooks = require('./lib/hooks');
 
 const PLUGIN_NAME = 'amqp-transport';
-const PLUGIN_TAG = require('./package.json').version;
+const PLUGIN_TAG = require('./package.json').version.replace(/\./g, '_'); // replacing dots with underscore, since dots are not allowed in tags anymore
 const TRANSPORT_TYPE = 'amqp';
 
 module.exports = function(opts) {


### PR DESCRIPTION
The regex for allowed tags has changed to `/^[a-zA-Z][a-zA-Z0-9_]*$/)`, therefore dots are not allowed anymore. replacing dots with underscore lets folks use this plugin again.